### PR TITLE
copy missing implementation of xradio_check_go_neg_conf_success from tx.c

### DIFF
--- a/rx.c
+++ b/rx.c
@@ -8,6 +8,20 @@
 #include "bh.h"
 #include "ap.h"
 
+static void xradio_check_go_neg_conf_success(struct xradio_common *hw_priv,
+						u8 *action)
+{
+	if (action[2] == 0x50 && action[3] == 0x6F && action[4] == 0x9A &&
+		action[5] == 0x09 && action[6] == 0x02) {
+		if(action[17] == 0) {
+			hw_priv->is_go_thru_go_neg = true;
+		}
+		else {
+			hw_priv->is_go_thru_go_neg = false;
+		}
+	}
+}
+
 static int xradio_handle_pspoll(struct xradio_vif *priv,
 				struct sk_buff *skb)
 {


### PR DESCRIPTION
o compile the default with CONFIG_XRADIO_USE_EXTENSIONS := y this seems to be required, as otherwise:

rx.c:122:3: error: implicit declaration of function ‘xradio_check_go_neg_conf_success’ [-Werror=implicit-function-declaration]
xradio_check_go_neg_conf_success(hw_priv, action);
